### PR TITLE
Increase compiler warnings and errors.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,13 @@
+{erl_opts, [
+            debug_info,
+            compressed,
+            report,
+            warn_export_all, warn_export_vars, warn_shadow_vars,
+            warn_unused_function, warn_deprecated_function,
+            warn_obsolete_guard, warn_unused_import,
+            warnings_as_errors
+           ]}.
+
 {deps, [
 	{rabbit_common, ".*", {git, "git://github.com/jbrisbin/rabbit_common.git", {tag, "rabbitmq_2.7.0"}}}
 ]}.


### PR DESCRIPTION
Upstream projects that require this library and use more stringent error
checking during compilation will fail if if this library introduces such
errors. As of this commit, 'rebar compile' now fails, owing to issues with
jbrisbin/rabbit_common fixed in

```
https://github.com/jbrisbin/rabbit_common/pull/1
```

Depending on upstream's fix, a new tag might need to be dropped into the
deps. Semantic Versioning as tags would make this somewhat more simple.

Signed-off-by: Brian L. Troutwine brian@troutwine.us
