### PR TITLE
update app file to match the official

### DIFF
--- a/src/amqp_client.app.src
+++ b/src/amqp_client.app.src
@@ -3,6 +3,6 @@
   {vsn, "3.0.0"},
   {modules, []},
   {registered, []},
-  {env, []},
+  {env, [{prefer_ipv6, false}]},
   {mod, {amqp_client, []}},
   {applications, [kernel, stdlib]}]}.


### PR DESCRIPTION
This fixes an error when you use the default amqp_client config

(ubic@127.0.0.1)3> {ok, Connection} = amqp_connection:start(#amqp_params_network{}).

=ERROR REPORT==== 11-Feb-2013::16:03:31 ===
*\* Generic server <0.293.0> terminating 
*\* Last message in was connect
*\* When Server state == {state,amqp_network_connection,
                            {state,undefined,undefined,undefined,undefined,
                                undefined,false},
                            <0.292.0>,undefined,
                            {amqp_params_network,<<"guest">>,<<"guest">>,
                                <<"/">>,"localhost",5672,0,0,0,infinity,none,
                                [#Fun<amqp_auth_mechanisms.plain.3>,
                                 #Fun<amqp_auth_mechanisms.amqplain.3>],
                                [],[]},
                            undefined,undefined,
                            #Fun<amqp_connection_sup.0.55585968>,
                            #Fun<amqp_connection_sup.2.55585968>,false}
*\* Reason for termination == 
*\* {{case_clause,undefined},
    [{amqp_network_connection,inet_address_preference,0,
                              [{file,"src/amqp_network_connection.erl"},
                               {line,154}]},
     {amqp_network_connection,gethostaddr,1,
                              [{file,"src/amqp_network_connection.erl"},
                               {line,161}]},
     {amqp_network_connection,connect,4,
                              [{file,"src/amqp_network_connection.erl"},
                               {line,110}]},
     {amqp_gen_connection,handle_call,3,
                          [{file,"src/amqp_gen_connection.erl"},{line,177}]},
     {gen_server,handle_msg,5,[{file,"gen_server.erl"},{line,588}]},
     {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,227}]}]}
