### PR TITLE
amqp_client.app should include rabbit_common in its applications list

### DIFF
--- a/src/amqp_client.app.src
+++ b/src/amqp_client.app.src
@@ -5,4 +5,4 @@
   {registered, [amqp_sup]},
   {env, [{prefer_ipv6, false}]},
   {mod, {amqp_client, []}},
-  {applications, [kernel, stdlib]}]}.
+  {applications, [kernel, stdlib, rabbit_common]}]}.


### PR DESCRIPTION
otherwise reltool fails to discover the dependency
