### PR TITLE
Update to RabbitMQ 3.4.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,17 +1,17 @@
 {deps, [
-	{rabbit_common, ".*", {git, "git://github.com/jbrisbin/rabbit_common.git", {tag, "rabbitmq-3.3.5"}}}
+  {rabbit_common, ".*", {git, "git://github.com/jbrisbin/rabbit_common.git", {tag, "rabbitmq-3.4.0"}}}
 ]}.
 
 {erl_opts, [
-  debug_info, 
-  compressed, 
-  report, 
-  warn_export_all, 
-  warn_export_vars, 
-  warn_shadow_vars, 
-  warn_unused_function, 
-  warn_deprecated_function, 
-  warn_obsolete_guard, 
-  warn_unused_import 
-%  warnings_as_errors
+  debug_info,
+  compressed,
+  report,
+  warn_export_all,
+  warn_export_vars,
+  warn_shadow_vars,
+  warn_unused_function,
+  warn_deprecated_function,
+  warn_obsolete_guard,
+  warn_unused_import,
+  warnings_as_errors
 ]}.

--- a/src/amqp_channel.erl
+++ b/src/amqp_channel.erl
@@ -74,7 +74,8 @@
 -export([call_consumer/2, subscribe/3]).
 -export([next_publish_seqno/1, wait_for_confirms/1, wait_for_confirms/2,
          wait_for_confirms_or_die/1, wait_for_confirms_or_die/2]).
--export([start_link/5, set_writer/2, connection_closing/3, open/1]).
+-export([start_link/5, set_writer/2, connection_closing/3, open/1,
+         enable_delivery_flow_control/1, notify_received/1]).
 
 -export([init/1, terminate/2, code_change/3, handle_call/3, handle_cast/2,
          handle_info/2]).
@@ -97,7 +98,16 @@
                 flow_handler       = none,
                 unconfirmed_set    = gb_sets:new(),
                 waiting_set        = gb_trees:empty(),
-                only_acks_received = true
+                only_acks_received = true,
+
+                %% true | false, only relevant in the direct
+                %% client case.
+                %% when true, consumers will manually notify
+                %% queue pids using rabbit_amqqueue:notify_sent/2
+                %% to prevent the queue from overwhelming slow
+                %% consumers that use automatic acknowledgement
+                %% mode.
+                delivery_flow_control = false
                }).
 
 %%---------------------------------------------------------------------------
@@ -342,6 +352,12 @@ start_link(Driver, Connection, ChannelNumber, Consumer, Identity) ->
 set_writer(Pid, Writer) ->
     gen_server:cast(Pid, {set_writer, Writer}).
 
+enable_delivery_flow_control(Pid) ->
+    gen_server:cast(Pid, enable_delivery_flow_control).
+
+notify_received({Pid, QPid, ServerChPid}) ->
+    gen_server:cast(Pid, {send_notify, {QPid, ServerChPid}}).
+
 %% @private
 connection_closing(Pid, ChannelCloseType, Reason) ->
     gen_server:cast(Pid, {connection_closing, ChannelCloseType, Reason}).
@@ -399,8 +415,18 @@ handle_call({subscribe, BasicConsume, Subscriber}, From, State) ->
                             State).
 
 %% @private
+handle_cast({set_writer, Writer}, State = #state{driver = direct}) ->
+    link(Writer),
+    {noreply, State#state{writer = Writer}};
 handle_cast({set_writer, Writer}, State) ->
     {noreply, State#state{writer = Writer}};
+%% @private
+handle_cast(enable_delivery_flow_control, State) ->
+    {noreply, State#state{delivery_flow_control = true}};
+%% @private
+handle_cast({send_notify, {QPid, ChPid}}, State) ->
+    rabbit_amqqueue:notify_sent(QPid, ChPid),
+    {noreply, State};
 %% @private
 handle_cast({cast, Method, AmqpMsg, Sender, noflow}, State) ->
     handle_method_to_server(Method, AmqpMsg, none, Sender, noflow, State);
@@ -458,9 +484,15 @@ handle_info({send_command, Method, Content}, State) ->
     handle_method_from_server(Method, Content, State);
 %% Received from rabbit_channel in the direct case
 %% @private
-handle_info({send_command_and_notify, Q, ChPid, Method, Content}, State) ->
-    handle_method_from_server(Method, Content, State),
-    rabbit_amqqueue:notify_sent(Q, ChPid),
+handle_info({send_command_and_notify, QPid, ChPid,
+             Method = #'basic.deliver'{}, Content},
+            State = #state{delivery_flow_control = MFC}) ->
+    case MFC of
+        false -> handle_method_from_server(Method, Content, State),
+                 rabbit_amqqueue:notify_sent(QPid, ChPid);
+        true  -> handle_method_from_server(Method, Content,
+                                           {self(), QPid, ChPid}, State)
+    end,
     {noreply, State};
 %% This comes from the writer or rabbit_channel
 %% @private
@@ -633,7 +665,9 @@ pre_do(_, _, _, State) ->
 %% Handling of methods from the server
 %%---------------------------------------------------------------------------
 
-handle_method_from_server(Method, Content, State = #state{closing = Closing}) ->
+safely_handle_method_from_server(Method, Content,
+                                 Continuation,
+                                 State = #state{closing = Closing}) ->
     case is_connection_method(Method) of
         true -> server_misbehaved(
                     #amqp_error{name        = command_invalid,
@@ -651,10 +685,27 @@ handle_method_from_server(Method, Content, State = #state{closing = Closing}) ->
                                       "server because channel is closing~n",
                                       [self(), {Method, Content}]),
                             {noreply, State};
-                    true -> handle_method_from_server1(Method,
-                                                       amqp_msg(Content), State)
+                    true ->
+                         Continuation()
                  end
     end.
+
+handle_method_from_server(Method, Content, State) ->
+    Fun = fun () ->
+                  handle_method_from_server1(Method,
+                                             amqp_msg(Content), State)
+          end,
+    safely_handle_method_from_server(Method, Content, Fun, State).
+
+handle_method_from_server(Method = #'basic.deliver'{},
+                          Content, DeliveryCtx, State) ->
+    Fun = fun () ->
+                  handle_method_from_server1(Method,
+                                             amqp_msg(Content),
+                                             DeliveryCtx,
+                                             State)
+          end,
+    safely_handle_method_from_server(Method, Content, Fun, State).
 
 handle_method_from_server1(#'channel.open_ok'{}, none, State) ->
     {noreply, rpc_bottom_half(ok, State)};
@@ -738,6 +789,12 @@ handle_method_from_server1(Method, none, State) ->
     {noreply, rpc_bottom_half(Method, State)};
 handle_method_from_server1(Method, Content, State) ->
     {noreply, rpc_bottom_half({Method, Content}, State)}.
+
+%% only used with manual consumer-to-queue flow control
+handle_method_from_server1(#'basic.deliver'{} = Deliver, AmqpMsg,
+                           DeliveryCtx, State) ->
+    ok = call_to_consumer(Deliver, AmqpMsg, DeliveryCtx, State),
+    {noreply, State}.
 
 %%---------------------------------------------------------------------------
 %% Other handle_* functions
@@ -919,6 +976,9 @@ handle_wait_for_confirms(From, Timeout,
 
 call_to_consumer(Method, Args, #state{consumer = Consumer}) ->
     amqp_gen_consumer:call_consumer(Consumer, Method, Args).
+
+call_to_consumer(Method, Args, DeliveryCtx, #state{consumer = Consumer}) ->
+    amqp_gen_consumer:call_consumer(Consumer, Method, Args, DeliveryCtx).
 
 safe_cancel_timer(undefined) -> ok;
 safe_cancel_timer(TRef)      -> erlang:cancel_timer(TRef).

--- a/src/amqp_channel_sup.erl
+++ b/src/amqp_channel_sup.erl
@@ -53,7 +53,6 @@ start_writer(_Sup, direct, [ConnPid, Node, User, VHost, Collector],
         rpc:call(Node, rabbit_direct, start_channel,
                  [ChNumber, ChPid, ConnPid, ConnName, ?PROTOCOL, User,
                   VHost, ?CLIENT_CAPABILITIES, Collector]),
-    link(RabbitCh),
     RabbitCh;
 start_writer(Sup, network, [Sock, FrameMax], ConnName, ChNumber, ChPid) ->
     {ok, Writer} = supervisor2:start_child(

--- a/src/amqp_client.app.src
+++ b/src/amqp_client.app.src
@@ -1,6 +1,6 @@
 {application, amqp_client,
  [{description, "RabbitMQ Erlang Client Library"},
-  {vsn, "3.3.5"},
+  {vsn, "3.4.0"},
   {modules, []},
   {registered, [amqp_sup]},
   {env, [{prefer_ipv6, false}]},

--- a/src/amqp_direct_consumer.erl
+++ b/src/amqp_direct_consumer.erl
@@ -45,7 +45,8 @@
 -behaviour(amqp_gen_consumer).
 
 -export([init/1, handle_consume_ok/3, handle_consume/3, handle_cancel_ok/3,
-         handle_cancel/2, handle_server_cancel/2, handle_deliver/3,
+         handle_cancel/2, handle_server_cancel/2,
+         handle_deliver/3, handle_deliver/4,
          handle_info/2, handle_call/3, terminate/2]).
 
 %%---------------------------------------------------------------------------
@@ -86,6 +87,10 @@ handle_server_cancel(M, C) ->
 handle_deliver(M, A, C) ->
     C ! {M, A},
     {ok, C}.
+handle_deliver(M, A, DeliveryCtx, C) ->
+    C ! {M, A, DeliveryCtx},
+    {ok, C}.
+
 
 %% @private
 handle_info({'DOWN', _MRef, process, C, Info}, C) ->

--- a/src/amqp_network_connection.erl
+++ b/src/amqp_network_connection.erl
@@ -132,17 +132,23 @@ do_connect({Addr, Family},
         {error, _} = E -> E
     end;
 do_connect({Addr, Family},
-           AmqpParams = #amqp_params_network{ssl_options        = SslOpts,
+           AmqpParams = #amqp_params_network{ssl_options        = SslOpts0,
                                              port               = Port,
                                              connection_timeout = Timeout,
                                              socket_options     = ExtraOpts},
            SIF, State) ->
+    {ok, GlobalSslOpts} = application:get_env(amqp_client, ssl_options),
     app_utils:start_applications([asn1, crypto, public_key, ssl]),
     obtain(),
     case gen_tcp:connect(Addr, Port,
                          [Family | ?RABBIT_TCP_OPTS] ++ ExtraOpts,
                          Timeout) of
         {ok, Sock} ->
+            SslOpts = rabbit_networking:fix_ssl_options(
+                        orddict:to_list(
+                          orddict:merge(fun (_, _A, B) -> B end,
+                                        orddict:from_list(GlobalSslOpts),
+                                        orddict:from_list(SslOpts0)))),
             case ssl:connect(Sock, SslOpts) of
                 {ok, SslSock} ->
                     RabbitSslSock = #ssl_socket{ssl = SslSock, tcp = Sock},

--- a/src/amqp_rpc_client.erl
+++ b/src/amqp_rpc_client.erl
@@ -88,7 +88,8 @@ call(RpcClient, Payload) ->
 %% Sets up a reply queue for this client to listen on
 setup_reply_queue(State = #state{channel = Channel}) ->
     #'queue.declare_ok'{queue = Q} =
-        amqp_channel:call(Channel, #'queue.declare'{}),
+        amqp_channel:call(Channel, #'queue.declare'{exclusive   = true,
+                                                    auto_delete = true}),
     State#state{reply_queue = Q}.
 
 %% Registers this RPC client instance as a consumer to handle rpc responses

--- a/src/amqp_selective_consumer.erl
+++ b/src/amqp_selective_consumer.erl
@@ -45,7 +45,8 @@
 
 -export([register_default_consumer/2]).
 -export([init/1, handle_consume_ok/3, handle_consume/3, handle_cancel_ok/3,
-         handle_cancel/2, handle_server_cancel/2, handle_deliver/3,
+         handle_cancel/2, handle_server_cancel/2,
+         handle_deliver/3, handle_deliver/4,
          handle_info/2, handle_call/3, terminate/2]).
 
 -record(state, {consumers             = dict:new(), %% Tag -> ConsumerPid
@@ -154,8 +155,13 @@ handle_server_cancel(Cancel = #'basic.cancel'{nowait = true}, State) ->
     {ok, State1}.
 
 %% @private
-handle_deliver(Deliver, Message, State) ->
-    deliver(Deliver, Message, State),
+handle_deliver(Method, Message, State) ->
+    deliver(Method, Message, State),
+    {ok, State}.
+
+%% @private
+handle_deliver(Method, Message, DeliveryCtx, State) ->
+    deliver(Method, Message, DeliveryCtx, State),
     {ok, State}.
 
 %% @private
@@ -201,17 +207,25 @@ terminate(_Reason, State) ->
 %% Internal plumbing
 %%---------------------------------------------------------------------------
 
-deliver(Msg, State) ->
-    deliver(Msg, undefined, State).
-deliver(Msg, Message, State) ->
-    Combined = if Message =:= undefined -> Msg;
-                  true                  -> {Msg, Message}
-               end,
-    case resolve_consumer(tag(Msg), State) of
-        {consumer, Pid} -> Pid ! Combined;
-        {default, Pid}  -> Pid ! Combined;
+deliver_to_consumer_or_die(Method, Msg, State) ->
+    case resolve_consumer(tag(Method), State) of
+        {consumer, Pid} -> Pid ! Msg;
+        {default, Pid}  -> Pid ! Msg;
         error           -> exit(unexpected_delivery_and_no_default_consumer)
     end.
+
+deliver(Method, State) ->
+    deliver(Method, undefined, State).
+deliver(Method, Message, State) ->
+    Combined = if Message =:= undefined -> Method;
+                  true                  -> {Method, Message}
+               end,
+    deliver_to_consumer_or_die(Method, Combined, State).
+deliver(Method, Message, DeliveryCtx, State) ->
+    Combined = if Message =:= undefined -> Method;
+                  true                  -> {Method, Message, DeliveryCtx}
+               end,
+    deliver_to_consumer_or_die(Method, Combined, State).
 
 do_cancel(Cancel, State = #state{consumers = Consumers,
                                  monitors  = Monitors}) ->


### PR DESCRIPTION
Updated from the mercurial repository, tag "rabbitmq_v3_4_0".

Line 78 of `amqp_direct_connection.erl` was edited manually to underscore the Node variable name and remove the compiler warning `src/amqp_direct_connection.erl:78: Warning: variable 'Node' is unused`. I'll report this upstream in case it has not been fixed in master.

This update was tested using the test suite in the Elixir amqp wrapper.

Detail of the changed line:

``` erlang
handle_message({'DOWN', _MRef, process, _ConnSup, Reason},
               State = #state{node = _Node}) ->
    {stop, {remote_node_down, Reason}, State};
```
