### PR TITLE
Use HTTPS instead of the unencrypted, unauthenticated, Git protocol

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {deps, [
-  {rabbit_common, ".*", {git, "git://github.com/jbrisbin/rabbit_common.git", {tag, "rabbitmq-3.5.0"}}}
+  {rabbit_common, ".*", {git, "https://github.com/jbrisbin/rabbit_common.git", {tag, "rabbitmq-3.5.0"}}}
 ]}.
 
 {erl_opts, [


### PR DESCRIPTION
This patch uses https:// instead of git:// for fetching `rabbit_common`. This patch won't interfere with people's Travis CI setups and should be a completely silently update, but will add some extra security benefits of https :-)