### PR TITLE
Add missing xmerl dependency in amqp_client.app.src.

### DIFF
--- a/src/amqp_client.app.src
+++ b/src/amqp_client.app.src
@@ -5,4 +5,4 @@
   {registered, [amqp_sup]},
   {env, [{prefer_ipv6, false}]},
   {mod, {amqp_client, []}},
-  {applications, [kernel, stdlib, rabbit_common]}]}.
+  {applications, [kernel, stdlib, rabbit_common, xmerl]}]}.


### PR DESCRIPTION
This patch is fixed upstream in:
19b842b26b76dd3a1f23d2a9888ff349b52924da.

This patch fixes issue #19.