### PR TITLE
Fix a typo that leads the reader to a non-existent tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To use the "community" branch in your project, which includes stricter compilati
 to the version tag:
 
     {deps, [
-      {amqp_client, ".*", {git, "git://github.com/jbrisbin/amqp_client.git", {tag, "rabbitmq-3.5.0-community"}}}
+      {amqp_client, ".*", {git, "git://github.com/jbrisbin/amqp_client.git", {tag, "rabbitmq-3.5.6-community"}}}
     ]}.
 
 ### License


### PR DESCRIPTION
This fooled me for awhile. 

I'm still having a problem including amqp_client as a rebar dependency. Can you see what is wrong with my code?

![image](https://cloud.githubusercontent.com/assets/120615/12662711/3903fe68-c5f0-11e5-86cd-6e74b88a09d9.png)

I'm not certain that the screen image I pasted is visible. If not, can you please give me an example that includes 3.5.6-community as a dependency. I've matched the line in README. It doesn't work for me.

Thank you for your help.

Carl A. Wright