### PR TITLE
fixes wrong rabbit_common version issue on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: erlang
 sudo: false
 
 otp_release:
-   - R16B03
    - 17.5
-   - 18.1
+   - 18.3
+   - 19.0
 
 script: "make"
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,5 @@
+{require_otp_vsn, "17|18|19"}.
+
 {deps, [
   {rabbit_common, ".*", {git, "https://github.com/jbrisbin/rabbit_common.git", ""}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {deps, [
-  {rabbit_common, ".*", {git, "https://github.com/jbrisbin/rabbit_common.git", {tag, "rabbitmq-3.5.6"}}}
+  {rabbit_common, ".*", {git, "https://github.com/jbrisbin/rabbit_common.git", ""}}
 ]}.
 
 {erl_opts, [


### PR DESCRIPTION
see #32 and #33 
This change is just a workaround for getting an working version for OTP19.
It will work with rebar and rebar3