### PR TITLE
Set version on rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {require_otp_vsn, "17|18|19"}.
 
 {deps, [
-  {rabbit_common, ".*", {git, "https://github.com/jbrisbin/rabbit_common.git", ""}}
+  {rabbit_common, ".*", {git, "https://github.com/jbrisbin/rabbit_common.git", "rabbitmq-3.5.6"}}
 ]}.
 
 {erl_opts, [


### PR DESCRIPTION
Fixes following compile error:
```
/bin/install: target ‘/opt/ejabberd/lib/[],/ebin/mochijson2.beam’ is not a directory
```